### PR TITLE
Tweaked Github Workflow so that it only commits if translation changes were actually made

### DIFF
--- a/.github/workflows/update_translation_progress.yml
+++ b/.github/workflows/update_translation_progress.yml
@@ -41,6 +41,10 @@ jobs:
 
       - name: Commit and Push
         run: |
+          if git diff --quiet -- ':!README.md'; then
+            echo "No changes to files other than README, skipping commit and push"
+            exit 0
+          fi
           git add docs/translations-light.svg docs/translations-dark.svg README.md
-          git commit -m "Update translation progress SVG and README cache-busting timestamp" || echo "No changes to commit"
+          git commit -m "Update translation progress SVG and README cache-busting timestamp"
           git push https://x-access-token:${{ secrets.PAT_TOKEN }}@github.com/${{ github.repository }} HEAD:master


### PR DESCRIPTION
This fixes having 2 commits a day, literally every day, even if nothing changed:

<img width="689" height="1062" alt="image" src="https://github.com/user-attachments/assets/fbe13722-4434-4423-9f8f-eb371e621441" />


` || echo "No changes to commit"` never fired because the README is _always_ modified.

There are other ways you could do this. This seems the simplest, but I'm fine with whatever works.